### PR TITLE
Updates to DID and W3C documentation pages

### DIFF
--- a/docs/api_testing/api_testing_intro.md
+++ b/docs/api_testing/api_testing_intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Introduction to API endpoint testing with DTT {#introduction-to-api-endpoint-testing-with-dtt}
+# Introduction to API endpoint testing with DTT
 
 This is an experimental test suite, which currently requires manual configuration work to enable additional endpoints (by ingesting and customizing its API specification). The goal is to focus on core VC exchange and management features such as *issue*, *verify*, and *revoke*, and to help you understand the interoperability capabilities of a specific endpoint by analyzing the interactions between this test suite and that endpoint.
 

--- a/docs/mdl_testing/mdl_testing_intro.md
+++ b/docs/mdl_testing/mdl_testing_intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Introduction to mDL testing with DTT {#introduction-to-mdl-testing-with-dtt}
+# Introduction to mDL testing with DTT
 
 With this experimental test suite, you can test your mDL mobile app by performing a data retrieval from Chrome over BLE (18013-5).
 Note: the test launches in a new tab, and the test results are not currently integrated with the rest of DTT.

--- a/docs/w3c_did/did_how_to_use.md
+++ b/docs/w3c_did/did_how_to_use.md
@@ -8,11 +8,28 @@ Please complete the access request form on the [DTT landing page](https://dtt.dt
 
 To get started, enter the URL representing a DID, and click on **Resolve DID URL**.
 
-## Need examples to try it out?
+## Need examples to try it out? {#DID_examples}
 
 [https://dev.uniresolver.io/](https://dev.uniresolver.io/) and [https://godiddy.com/app/resolve](https://godiddy.com/app/resolve) provide a number of examples for a variety of DID methods.
 Here are a few to get you started!
 
 >`did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN`\
->`did:ebsi:zkC6cUFUs3FiRp2xedNwih2`\
->`did:indy:indicio:demo:KKyAeG7woJMV6MhhAREVKp`
+>`did:ebsi:zxE9ucTwx5V7Aean5Kj6Lz3`\
+>`did:ethr:0x1:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736`\
+>`did:kscirc:k2xxMB9tYCPwg3pmCtGwHjEjwiRimVFhY8EevKMNu7mN9igGvYC`
+
+## Using the optional validation options {#using_the_options}
+
+The DID resolver supports various advanced resolution features. They are defined in the [did-spec-extensions](https://github.com/decentralized-identity/did-spec-extensions?tab=readme-ov-file#extension-resolution-options). If you do not want to see those potential warnings in your test report, simply change the relevant option(s) from `true` to `false` and click on **Set test profile** to save your choices before clicking on **Resolve DID URL**.
+
+| Option name                    | DTT DID test                      | Explanation                                                                                                                                                                |
+| ------------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `checkValidDidDocument`        | \#1 Valid DID Document Check      | Checks if the DID document **conforms with the W3C DID v1.0 specification**.                                                                                              |
+| `checkMethod`                  | \#2 Allowed DID Method Check      | Checks if the DID method is not allowed, based on an allowlist and denylist.                                                                                               |
+| `checkVerificationMethodType`  | \#3 Allowed Verification Method Type Check | Checks if the DID document contains a verification method with a type that is not allowed, based on an allowlist and denylist.                                               |
+| `checkCertificate`             | \#4 Certificate Chain Validation Check | Checks if a DID document contains a key that cannot be traced back to a trusted certificate authority, based on an allowlist and denylist.                                     |
+| `checkDns`                     | \#5 DNS Validation Check          | Checks if a DID document contains a domain name that cannot be verified via DNS, based on an allowlist and denylist.                                                         |
+| `checkKeyType`                 | \#6 Allowed Key Type Check        | Checks if the DID document contains a key type that is not allowed, based on an allowlist and denylist.                                                                     |
+| `checkLocalDerivedKey`         | \#7 Local Derived Key Check       | Checks if derived keys have been detected in the DID document, e.g., an X25519 key derived from an Ed25519 key.                                                              |
+| `checkLocalDuplicateKey`       | \#8 Duplicate Key Check           | Checks if duplicate keys have been detected in the DID document.                                                                                                           |
+| `checkGlobalDuplicateKey`      | \#9 Global Duplicate Key Check    | Checks if duplicate keys have been detected between the DID document and other globally known DID documents.                                                                |

--- a/docs/w3c_did/did_how_to_use.md
+++ b/docs/w3c_did/did_how_to_use.md
@@ -13,7 +13,6 @@ To get started, enter the URL representing a DID, and click on **Resolve DID URL
 [https://dev.uniresolver.io/](https://dev.uniresolver.io/) and [https://godiddy.com/app/resolve](https://godiddy.com/app/resolve) provide a number of examples for a variety of DID methods.
 Here are a few to get you started!
 
->`did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN`\
 >`did:ebsi:zxE9ucTwx5V7Aean5Kj6Lz3`\
 >`did:ethr:0x1:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736`\
 >`did:kscirc:k2xxMB9tYCPwg3pmCtGwHjEjwiRimVFhY8EevKMNu7mN9igGvYC`
@@ -21,10 +20,11 @@ Here are a few to get you started!
 ## Using the optional validation options {#using_the_options}
 
 The DID resolver supports various advanced resolution features. They are defined in the [did-spec-extensions](https://github.com/decentralized-identity/did-spec-extensions?tab=readme-ov-file#extension-resolution-options). If you do not want to see those potential warnings in your test report, simply change the relevant option(s) from `true` to `false` and click on **Set test profile** to save your choices before clicking on **Resolve DID URL**.
+Please note that some of these features are experimental!
 
 | Option name                    | DTT DID test                      | Explanation                                                                                                                                                                |
 | ------------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `checkValidDidDocument`        | \#1 Valid DID Document Check      | Checks if the DID document **conforms with the W3C DID v1.0 specification**.                                                                                              |
+| `checkValidDidDocument`        | \#1 Valid DID Document Check      | Checks if the DID document **conforms with the W3C DID v1.0 specification**. This validation is performed by [DID Lint](https://didlint.ownyourdata.eu/validate)           |
 | `checkMethod`                  | \#2 Allowed DID Method Check      | Checks if the DID method is not allowed, based on an allowlist and denylist.                                                                                               |
 | `checkVerificationMethodType`  | \#3 Allowed Verification Method Type Check | Checks if the DID document contains a verification method with a type that is not allowed, based on an allowlist and denylist.                                               |
 | `checkCertificate`             | \#4 Certificate Chain Validation Check | Checks if a DID document contains a key that cannot be traced back to a trusted certificate authority, based on an allowlist and denylist.                                     |

--- a/docs/w3c_vcdm/vcdm_about.md
+++ b/docs/w3c_vcdm/vcdm_about.md
@@ -8,6 +8,6 @@ sidebar_position: 4
 
 * Learn more about the W3C Verifiable Credential Data Model:
   * Verifiable Credentials Data Model v1.1 - [W3C Recommendation](https://www.w3.org/TR/vc-data-model/)
-  * Verifiable Credentials Data Model v2.0 - [W3C Candidate Recommendation Draft](https://www.w3.org/TR/vc-data-model-2.0/)
+  * Verifiable Credentials Data Model v2.0 - [W3C Proposed Recommendation](https://www.w3.org/TR/vc-data-model-2.0/)
   
 * Get involved: [Verifiable Credentials Working Group](https://www.w3.org/2017/vc/WG/)

--- a/docs/w3c_vcdm/vcdm_specs.md
+++ b/docs/w3c_vcdm/vcdm_specs.md
@@ -4,4 +4,4 @@ sidebar_position: 2
 
 # Standards and specifications for the W3C Verifiable Credential Data Model
 
-The W3C [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/) specification was published as a recommendation in March of 2022, while the [Verifiable Credentials Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) specification was first published as a Candidate Recommendation Draft in 2024. There are various clarifications and updates worth noting, such as the way validity and expiration dates are handled. Happy exploring with DTT!
+The W3C [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/) specification was published as a recommendation in March of 2022, while the [Verifiable Credentials Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) specification became a proposed recommendation in March 2025, having being first published as a Candidate Recommendation Draft in 2024. There are various clarifications and updates worth noting, such as the way validity and expiration dates are handled. Happy exploring with DTT!


### PR DESCRIPTION
- removed cheqd DID examples
- clarified DID resolution options based on discussions with Danube about how godiddy implements some of those validations
- updated status of W3C VCDM 2.0 specification